### PR TITLE
Python3 compatibility

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -9,15 +9,11 @@ import os
 import sys
 import argparse
 from plugins.banner import *
-try:
-    import requests
-    import warnings
-    import urllib.parse
-    import socket
-    import multiprocessing
-except ModuleNotFoundError:
-    print("Importing Some required modules.")
-    os.system("pip install -r requirements.txt")
+import requests
+import warnings
+import urllib.parse
+import socket
+import multiprocessing
 
 warnings.filterwarnings("ignore")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
 requests
-warnings
-urllib.parse
-socket
-multiprocessing


### PR DESCRIPTION
The import inside the try did not function for me for some reason. I eliminated the try catch statement and it now works, most likely due to the try's scope.

Additionally, I eliminated certain imports that are included by default in Python 3.

All of them existed due of Python2 compatibility?

Please let me know and test it, but this should work out of the box.
maybe check for indenting mistakes.